### PR TITLE
[OPT] change double into float

### DIFF
--- a/seance_2/PROJET_2_Quadratique.md
+++ b/seance_2/PROJET_2_Quadratique.md
@@ -39,20 +39,20 @@ int main()
   <summary>J'ai besoin d'aide ! 😱</summary>
   <p>
 
-  Le type de données ici doit être double (et non int).
+  Le type de données ici doit être ``float`` (et non ``int``).
 
-  Vous pouvez déclarer trois variables doubles comme suit :
+  Vous pouvez déclarer trois variables ``float`` comme suit :
 
   ```cpp
-  double a;
-  double b;
-  double c;
+  float a;
+  float b;
+  float c;
   ```
 
   ou
 
   ```cpp
-  double a, b, c;
+  float a, b, c;
   ```
 
   </p>


### PR DESCRIPTION
Dans le cadre de cet exercice, typer les variables en double est une mauvaise utilisation de la mémoire. En effet, les ``double`` étant encodé sur 64bit ont un précision d'environ 15 à 17 chiffres après la virgule ce qui est inutile étant donné que (par défaut et comme montré dans l'exemple) ``printf`` n'a une précision que de 6 chiffres après la virgule. Cette précision est apportée par un simple ``float`` (encodé sur 32bit et donc ayant une précision d'environ 7 à 9 chiffres après la virgule).